### PR TITLE
Temp disable matchlist service dependents

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,11 +2,10 @@ import { Module } from '@nestjs/common'
 import { ConfigurationModule } from '../config'
 import { HealthModule } from '../health/health.module'
 import { MasteryModule } from '../mastery/mastery.module'
-import { MatchlistModule } from '../matchlist/matchlist.module'
+// import { MatchlistModule } from '../matchlist/matchlist.module'
 import { SharedModule } from '../shared/shared.module'
-import { StatsModule } from '../stats/stats.module'
+// import { StatsModule } from '../stats/stats.module'
 import { UserModule } from '../user/user.module'
-// local
 import { AppController } from './app.controller'
 
 @Module({
@@ -16,8 +15,9 @@ import { AppController } from './app.controller'
 		ConfigurationModule, // contains config endpoints
 		HealthModule, // contains health endpoints
 		MasteryModule, // contains user endpoints
-		MatchlistModule, // contains matchlist endpoints
-		StatsModule, // contains stats endpoints
+		// TODO - below not available until Riot makes match v5 API available to production API keys
+		// MatchlistModule, // contains matchlist endpoints
+		// StatsModule, // contains stats endpoints
 		UserModule, // contains user endpoints
 	],
 	providers: [],


### PR DESCRIPTION
Need to wait until Riot make the match v5 API available to production API keys

![image](https://user-images.githubusercontent.com/2125913/125709504-a6f09207-5a74-41f8-acc9-169ed41e1000.png)

![image](https://user-images.githubusercontent.com/2125913/125709520-830d805a-74c5-4a5b-a628-af069893b326.png)
